### PR TITLE
fix: set buftype to nofile so that the plugin does not save the cell by accident

### DIFF
--- a/lua/easytables/window.lua
+++ b/lua/easytables/window.lua
@@ -117,6 +117,8 @@ function M:_open_preview_window()
         height = 1
     })
 
+    vim.api.nvim_set_option_value("buftype", "nofile", { buf = self.preview_buffer })
+
     -- Disable default highlight
     vim.api.nvim_set_option_value(
         "winhighlight",
@@ -145,6 +147,8 @@ function M:_open_prompt_window()
         width = 1,
         height = 1
     })
+
+    vim.api.nvim_set_option_value("buftype", "nofile", { buf = self.prompt_buffer })
 
     vim.api.nvim_set_option_value('winhighlight', "Normal:Normal", { win = self.prompt_window })
 end


### PR DESCRIPTION
When editing a cell in the prompt window, users may be tempted to do `:w` due to muscle memory or just intuition. This will create random temporary files named `[Table Cell: 2x2]` etc. which I believe are not desired.

This PR set the `buftype` option of the prompt buffer to `nofile` so that there'll be a warning when the user tries to do `:w` in the prompt and the temporary files for the prompt buffer will not be saved, hence fixing the issue mentioned above.